### PR TITLE
Feature/merge plain and shared templates with handlebars

### DIFF
--- a/generators/createBanner/index.js
+++ b/generators/createBanner/index.js
@@ -88,6 +88,36 @@ module.exports = class extends Generator {
           },
         ])),
       };
+
+      if (this.result.isShared) {
+        this.result.folderSharedExists = false;
+        if (this.fs.exists(this.destinationPath('package.json'))) {
+
+          let json = this.fs.readJSON(this.destinationPath('package.json'));
+          if(json.shared) {
+            this.result.folderSharedExists = true;
+            this.result.sharedFolder = json.shared;
+            this.log(`Shared folder already exists`);
+          } else {
+            this.result = {
+              ...this.result,
+              ...(await this.prompt([
+                {
+                  type: 'input',
+                  name: 'sharedFolder',
+                  message: 'what is the name of your shared folder?',
+                  default: 'shared'
+                },
+              ])),
+            };
+          }
+
+        }
+
+
+
+
+      }
     }
   }
 

--- a/generators/createBanner/plain.js
+++ b/generators/createBanner/plain.js
@@ -12,34 +12,50 @@ module.exports = class extends Generator {
   async action() {
     const [width, height] = this.options.size.split('x');
 
-    this.fs.extendJSON(
-      this.destinationPath('package.json'),
-      this.fs.readJSON(this.templatePath('plain/extendPackageJson.json')),
-    );
+    if(!this.options.folderSharedExists) {
+      const jsonPackage = deepmerge(this.fs.readJSON(this.templatePath('plain/extendPackageJson.json')), {
+        shared: this.options.sharedFolder,
+      });
+
+      this.fs.extendJSON(
+        this.destinationPath('package.json'),
+        jsonPackage,
+      );
+    }
+
+
+
+
 
     this.fs.copyTpl(
       this.templatePath('plain/banner'),
       this.destinationPath(path.join(this.options.outputPath)),
       {
-        shared: this.options.isShared,
+        shared: this.options.sharedFolder,
         banner_width: width,
         banner_height: height,
+        bannerPath: "'../../../"+this.options.sharedFolder+"/script/Banner'",
+        animationPath: "'../../../"+this.options.sharedFolder+"/script/Animation'",
       },
     );
 
     if(this.options.isShared) {
-      this.fs.copy(
-        this.templatePath('plain/shared/img'),
-        this.destinationPath(path.join(this.options.outputPath), '../../shared/img'),
-      );
+      if(!this.options.folderSharedExists) {
+        this.fs.copy(
+          this.templatePath('plain/shared/img'),
+          this.destinationPath(path.join(this.options.outputPath), '../../' + this.options.sharedFolder + '/img'),
+        );
 
-      this.fs.copyTpl(
-        this.templatePath('plain/shared/script'),
-        this.destinationPath(path.join(this.options.outputPath, '../../shared/script')),
-        {
-          shared: this.options.isShared,
-        },
-      );
+        this.fs.copyTpl(
+          this.templatePath('plain/shared/script'),
+          this.destinationPath(path.join(this.options.outputPath, '../../' + this.options.sharedFolder + '/script')),
+          {
+            shared: this.options.isShared,
+            bannerPath: "'../../../" + this.options.sharedFolder + "/script/Banner'",
+            animationPath: "'../../../" + this.options.sharedFolder + "/script/Animation'",
+          },
+        );
+      }
     } else {
       this.fs.copy(
         this.templatePath('plain/shared/img'),
@@ -50,7 +66,7 @@ module.exports = class extends Generator {
         this.templatePath('plain/shared/script'),
         this.destinationPath(path.join(this.options.outputPath, 'script')),
         {
-          shared: this.options.isShared,
+          shared: this.options.isShared
         },
       );
     }
@@ -58,7 +74,7 @@ module.exports = class extends Generator {
 
     const json = deepmerge(this.fs.readJSON(this.templatePath('plain/banner/.richmediarc')), {
       content: {
-        logo: this.options.isShared ? "../../shared/img/logo.svg" : "./img/logo.svg",
+        logo: this.options.isShared ? "../../"+this.options.sharedFolder+"/img/logo.svg" : "./img/logo.svg",
       },
       settings: {
         type: this.options.isShared ? "plain-shared" : "plain",

--- a/generators/createBanner/templates/plain/banner/script/main.js
+++ b/generators/createBanner/templates/plain/banner/script/main.js
@@ -1,6 +1,6 @@
 <% if (shared) { %>
-import Banner from "../../../shared/script/Banner";
-import Animation from "../../../shared/script/Animation";
+import Banner from <%- bannerPath %>;
+import Animation from <%- animationPath %>;
 <% } else{ %>
 import Banner from "./Banner";
 import Animation from "./Animation";

--- a/generators/createBanner/templates/plain/extendPackageJson.json
+++ b/generators/createBanner/templates/plain/extendPackageJson.json
@@ -1,5 +1,6 @@
 {
   "dependencies": {
 
-  }
+  },
+  "shared": 0
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-richmedia-temple",
-  "version": "5.6.4",
+  "version": "5.6.5",
   "description": "",
   "homepage": "",
   "author": "",


### PR DESCRIPTION
Closes #74
- You have the ability to set your own lib folder name now 
- the shared folder will be kept track of in the package.json so that when it excists it will not overwrite the previous one